### PR TITLE
Use pyelftools instead of parsing readelf output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It works on both executables and libraries.
 - A Linux system (copydeps might work on BSD systems, but this has not been
   tested)
 - Python 3
-- readelf
+- [pyelftools](https://github.com/eliben/pyelftools)
 - ldd
 
 ## Installation

--- a/copydeps.py
+++ b/copydeps.py
@@ -2,7 +2,6 @@
 import argparse
 import fnmatch
 import os
-import re
 import shutil
 import subprocess
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyelftools==0.24

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     platforms=['Linux'],
     url='https://github.com/genymobile/copydeps',
     py_modules=['copydeps'],
+    install_requires=['pyelftools'],
     entry_points={
         'console_scripts': [
             'copydeps = copydeps:main',


### PR DESCRIPTION
Using a Python module instead of parsing the output of the readelf binary should be more robust in the long term.