### PR TITLE
Support local shared objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 copydeps.egg-info
 .*.swp
+.cache

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,12 +1,18 @@
 Contributions are welcome!
 
-To submit a patch, first make sure your Python code follows [PEP 8][PEP8].
+To submit a patch, check the following:
+
+1. Make sure your Python code follows [PEP 8][PEP8].
 
 You can check with the following command:
 
     flake8 --filename '*' --ignore E501 copydeps
 
 (We ignore E501, line length because the code contains output of commands)
+
+2. Make sure tests pass. You can run the test suite with:
+
+    pytest
 
 Then file a [pull request][PR] against the master branch.
 

--- a/copydeps.py
+++ b/copydeps.py
@@ -32,9 +32,8 @@ class MissingLibrariesError(Exception):
 
 
 def printerr(*args, **kwargs):
-    kwargs_ = dict(kwargs)
-    kwargs_['file'] = sys.stderr
-    print(*args, **kwargs_)
+    kwargs['file'] = sys.stderr
+    print(*args, **kwargs)
 
 
 def load_blacklist(filename):

--- a/copydeps.py
+++ b/copydeps.py
@@ -36,11 +36,16 @@ def load_blacklist(filename):
 
 
 def list_soname_paths(executable):
-    """Return a dict of the form soname => path"""
+    """Return a dict of the form soname => path for all the dependency of
+    the executable"""
     out = subprocess.check_output(('ldd', executable))
+    return parse_ldd_output(out)
 
+
+def parse_ldd_output(ldd_output):
+    """Return a dict of the form soname => path"""
     dct = {}
-    for line in out.splitlines():
+    for line in ldd_output.splitlines():
         line = line.strip().decode('ascii')
         # line can be one of:
         # 1. linux-vdso.so.1 =>  (0x00007ffd6f3cd000)

--- a/test_copydeps.py
+++ b/test_copydeps.py
@@ -1,0 +1,13 @@
+from copydeps import parse_ldd_output
+
+
+def test_parse_ldd_output():
+    LDD_OUTPUT = b"""
+    linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
+    libcrypto.so.1.0.0 => /home/ci/build/genymotion/./libcrypto.so.1.0.0 (0x00007f5ea40b6000)
+    /lib64/ld-linux-x86-64.so.2 (0x0000562cf1094000)
+    """
+    dct = parse_ldd_output(LDD_OUTPUT)
+    assert dct == {
+        'libcrypto.so.1.0.0': '/home/ci/build/genymotion/./libcrypto.so.1.0.0'
+    }

--- a/test_copydeps.py
+++ b/test_copydeps.py
@@ -4,20 +4,19 @@ from copydeps import parse_ldd_output, MissingLibrariesError
 
 
 def test_parse_ldd_output():
-    LDD_OUTPUT = b"""
-    linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
+    LDD_OUTPUT = b"""linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
     libcrypto.so.1.0.0 => /home/ci/build/genymotion/./libcrypto.so.1.0.0 (0x00007f5ea40b6000)
-    /lib64/ld-linux-x86-64.so.2 (0x0000562cf1094000)
+    ./libfoo.so.2 (0x0000562cf1094000)
     """
     dct = parse_ldd_output(LDD_OUTPUT)
     assert dct == {
-        'libcrypto.so.1.0.0': '/home/ci/build/genymotion/./libcrypto.so.1.0.0'
+        'libcrypto.so.1.0.0': '/home/ci/build/genymotion/./libcrypto.so.1.0.0',
+        './libfoo.so.2': './libfoo.so.2',
     }
 
 
 def test_parse_ldd_output_library_not_found():
-    LDD_OUTPUT = b"""
-    linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
+    LDD_OUTPUT = b"""linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
     libstdc++.so.5 => not found
     libbar.so.2 => not found
     """

--- a/test_copydeps.py
+++ b/test_copydeps.py
@@ -1,4 +1,6 @@
-from copydeps import parse_ldd_output
+import pytest
+
+from copydeps import parse_ldd_output, MissingLibrariesError
 
 
 def test_parse_ldd_output():
@@ -11,3 +13,14 @@ def test_parse_ldd_output():
     assert dct == {
         'libcrypto.so.1.0.0': '/home/ci/build/genymotion/./libcrypto.so.1.0.0'
     }
+
+
+def test_parse_ldd_output_library_not_found():
+    LDD_OUTPUT = b"""
+    linux-vdso.so.1 =>  (0x00007ffd6f3cd000)
+    libstdc++.so.5 => not found
+    libbar.so.2 => not found
+    """
+    with pytest.raises(MissingLibrariesError) as excinfo:
+        parse_ldd_output(LDD_OUTPUT)
+    assert excinfo.value.libs == ['libstdc++.so.5', 'libbar.so.2']


### PR DESCRIPTION
This PR does the following:
- Extracts the code responsible for parsing ldd output to a separate function, so that it can be unit-tested
- Add unit tests to the ldd output parser
- Improve handling of missing libraries: do not report them as an assert failure, and report them all instead of stopping at the first missing library
- Make sure the parser supports local shared objects, to fix #7