### PR TITLE
Check soname in dictionary

### DIFF
--- a/copydeps.py
+++ b/copydeps.py
@@ -156,12 +156,13 @@ class App:
             if soname in self.processed_sonames:
                 continue
             self.processed_sonames.add(soname)
-            path = self.path_for_binary[soname]
-            if self.dry_run:
-                printerr("Would copy {} to {}".format(path, self.destdir))
-            else:
-                copy(path, self.destdir)
-            self._traverse_tree(soname)
+            if soname in self.path_for_binary:
+                path = self.path_for_binary[soname]
+                if self.dry_run:
+                    printerr("Would copy {} to {}".format(path, self.destdir))
+                else:
+                    copy(path, self.destdir)
+                self._traverse_tree(soname)
 
     def _graph_excluded_dependency(self, binary, soname):
         self.dot_fp.write('  "{}" {};\n'.format(soname, DOT_EXCLUDED_ATTRS))


### PR DESCRIPTION
Hi!
I have an errorr with ld-linux-aarch64.so.1:

```
$python3 copydeps.py ~/work/tm/traffic_monitor/build/traffic_monitor -d ./tm
Traceback (most recent call last):
  File "copydeps.py", line 245, in <module>
    sys.exit(main())
  File "copydeps.py", line 228, in main
    app.run(args.executable)
  File "copydeps.py", line 138, in run
    self._traverse_tree(binary)
  File "copydeps.py", line 165, in _traverse_tree
    self._traverse_tree(soname)
  File "copydeps.py", line 165, in _traverse_tree
    self._traverse_tree(soname)
  File "copydeps.py", line 165, in _traverse_tree
    self._traverse_tree(soname)
  [Previous line repeated 2 more times]
  File "copydeps.py", line 143, in _traverse_tree
    path = self.path_for_binary[binary]
KeyError: 'ld-linux-aarch64.so.1'

```
And I added some condition then soname exists in self.path_for_binary